### PR TITLE
Changed postbuild events to be OS-conditional, and updated NUnit to v3.

### DIFF
--- a/OpenGL.Hal.Test/ArrayBufferObjectBase.cs
+++ b/OpenGL.Hal.Test/ArrayBufferObjectBase.cs
@@ -75,11 +75,16 @@ namespace OpenGL.Hal.Test
 
 		private static Array CreateTestArray()
 		{
-			if (typeof(T) == typeof(ArrayBufferObject)) {
+			if (typeof(T) == typeof(ArrayBufferObject))
+			{
 				return (new float[16]);
-			} else if (typeof(T) == typeof(ElementBufferObject)) {
+			}
+			else if (typeof(T) == typeof(ElementBufferObject))
+			{
 				return (new uint[16]);
-			} else if ((typeof(T) == typeof(ArrayBufferObjectInterleaved)) || (typeof(T) == typeof(ArrayBufferObjectPacked))) {
+			}
+			else if ((typeof(T) == typeof(ArrayBufferObjectInterleaved)) || (typeof(T) == typeof(ArrayBufferObjectPacked)))
+			{
 				return (new ComplexVertexElement[16]);
 			}
 
@@ -119,7 +124,8 @@ namespace OpenGL.Hal.Test
 
 			ArrayBufferObjectBase arrayBufferRef = null;
 
-			using (ArrayBufferObjectBase arrayBuffer = CreateInstance()) {
+			using (ArrayBufferObjectBase arrayBuffer = CreateInstance())
+			{
 				ConstructionDefaulValues(arrayBuffer);
 
 				// Create client buffer
@@ -189,12 +195,15 @@ namespace OpenGL.Hal.Test
 		public void CreateCount_NoExtension()
 		{
 			_Context.PushCaps();
-			try {
+			try
+			{
 				// Disable GL_ARB_vertex_array_object
 				_Context.Caps.GlExtensions.VertexBufferObject_ARB = false;
 
 				CreateCount_Core();
-			} finally {
+			}
+			finally
+			{
 				_Context.PopCaps();
 			}
 		}
@@ -202,12 +211,10 @@ namespace OpenGL.Hal.Test
 		/// <summary>
 		/// Test execptions on <see cref="ArrayBufferObject.Create(uint)"/>
 		/// </summary>
-		[Test, ExpectedException(typeof(ArgumentException))]
+		[Test]
 		public void CreateCount_Exception1()
 		{
-			using (ArrayBufferObjectBase arrayBuffer = CreateInstance()) {
-				arrayBuffer.Create(0);
-			}
+			Assert.Throws<ArgumentException>(() => CreateInstance().Create(0));
 		}
 
 		#endregion
@@ -223,7 +230,8 @@ namespace OpenGL.Hal.Test
 
 			ArrayBufferObjectBase arrayBufferRef = null;
 
-			using (ArrayBufferObjectBase arrayBuffer = CreateInstance()) {
+			using (ArrayBufferObjectBase arrayBuffer = CreateInstance())
+			{
 				ConstructionDefaulValues(arrayBuffer);
 
 				// Create GPU memory
@@ -249,7 +257,8 @@ namespace OpenGL.Hal.Test
 				arrayBufferRef = arrayBuffer;
 			}
 
-			if (arrayBufferRef != null) {
+			if (arrayBufferRef != null)
+			{
 				Assert.AreEqual(0, arrayBufferRef.ItemCount);
 				Assert.AreEqual(0, arrayBufferRef.ClientItemCount);
 			}
@@ -271,12 +280,15 @@ namespace OpenGL.Hal.Test
 		public void CreateCtxCount_NoExtension()
 		{
 			_Context.PushCaps();
-			try {
+			try
+			{
 				// Disable GL_ARB_vertex_array_object
 				_Context.Caps.GlExtensions.VertexBufferObject_ARB = false;
 
 				CreateCtxCount_Core();
-			} finally {
+			}
+			finally
+			{
 				_Context.PopCaps();
 			}
 		}
@@ -284,36 +296,30 @@ namespace OpenGL.Hal.Test
 		/// <summary>
 		/// Test execptions on <see cref="ArrayBufferObject.Create(GraphicsContext, uint)"/>
 		/// </summary>
-		[Test, ExpectedException(typeof(ArgumentNullException))]
+		[Test]
 		public void CreateCtxCount_Exception1()
 		{
-			using (ArrayBufferObjectBase arrayBuffer = CreateInstance()) {
-				arrayBuffer.Create((GraphicsContext)null, 0);
-			}
+			Assert.Throws<ArgumentNullException>(() => CreateInstance().Create((GraphicsContext)null, 0));
 		}
 
 		/// <summary>
 		/// Test execptions on <see cref="ArrayBufferObject.Create(GraphicsContext, uint)"/>
 		/// </summary>
-		[Test, ExpectedException(typeof(ArgumentException))]
+		[Test]
 		public void CreateCtxCount_Exception2()
 		{
 			_Context.MakeCurrent(false);
 
-			using (ArrayBufferObjectBase arrayBuffer = CreateInstance()) {
-				arrayBuffer.Create(_Context, 0);
-			}
+			Assert.Throws<ArgumentException>(() => CreateInstance().Create(_Context, 0));
 		}
 
 		/// <summary>
 		/// Test execptions on <see cref="ArrayBufferObject.Create(GraphicsContext, uint)"/>
 		/// </summary>
-		[Test, ExpectedException(typeof(ArgumentException))]
+		[Test]
 		public void CreateCtxCount_Exception3()
 		{
-			using (ArrayBufferObjectBase arrayBuffer = CreateInstance()) {
-				arrayBuffer.Create(_Context, 0);
-			}
+			Assert.Throws<ArgumentException>(() => CreateInstance().Create(_Context, 0));
 		}
 
 		#endregion
@@ -329,7 +335,8 @@ namespace OpenGL.Hal.Test
 
 			ArrayBufferObjectBase arrayBufferRef = null;
 
-			using (ArrayBufferObjectBase arrayBuffer = CreateInstance()) {
+			using (ArrayBufferObjectBase arrayBuffer = CreateInstance())
+			{
 				ConstructionDefaulValues(arrayBuffer);
 
 				// Create client memory
@@ -373,12 +380,15 @@ namespace OpenGL.Hal.Test
 		public void CreateArray_NoExtension()
 		{
 			_Context.PushCaps();
-			try {
+			try
+			{
 				// Disable GL_ARB_vertex_array_object
 				_Context.Caps.GlExtensions.VertexBufferObject_ARB = false;
 
 				CreateArray_Core();
-			} finally {
+			}
+			finally
+			{
 				_Context.PopCaps();
 			}
 		}
@@ -394,7 +404,8 @@ namespace OpenGL.Hal.Test
 		{
 			ArrayBufferObjectBase arrayBufferRef = null;
 
-			using (ArrayBufferObjectBase arrayBuffer = CreateInstance()) {
+			using (ArrayBufferObjectBase arrayBuffer = CreateInstance())
+			{
 				ConstructionDefaulValues(arrayBuffer);
 
 				// Create GPU memory
@@ -438,12 +449,15 @@ namespace OpenGL.Hal.Test
 		public void CreateCtxArray_NoExtension()
 		{
 			_Context.PushCaps();
-			try {
+			try
+			{
 				// Disable GL_ARB_vertex_array_object
 				_Context.Caps.GlExtensions.VertexBufferObject_ARB = false;
 
 				CreateCtxArray_Core();
-			} finally {
+			}
+			finally
+			{
 				_Context.PopCaps();
 			}
 		}
@@ -451,36 +465,30 @@ namespace OpenGL.Hal.Test
 		/// <summary>
 		/// Test execptions on <see cref="ArrayBufferObject.Create(GraphicsContext, uint)"/>
 		/// </summary>
-		[Test, ExpectedException(typeof(ArgumentNullException))]
+		[Test]
 		public void CreateCtxArray_Exception1()
 		{
-			using (ArrayBufferObjectBase arrayBuffer = CreateInstance()) {
-				arrayBuffer.Create((GraphicsContext)null, 0);
-			}
+			Assert.Throws<ArgumentNullException>(() => CreateInstance().Create((GraphicsContext)null, 0));
 		}
 
 		/// <summary>
 		/// Test execptions on <see cref="ArrayBufferObject.Create(GraphicsContext, uint)"/>
 		/// </summary>
-		[Test, ExpectedException(typeof(ArgumentException))]
+		[Test]
 		public void CreateCtxArray_Exception2()
 		{
 			_Context.MakeCurrent(false);
 
-			using (ArrayBufferObjectBase arrayBuffer = CreateInstance()) {
-				arrayBuffer.Create(_Context, 0);
-			}
+			Assert.Throws<ArgumentException>(() => CreateInstance().Create(_Context, 0));
 		}
 
 		/// <summary>
 		/// Test execptions on <see cref="ArrayBufferObject.Create(GraphicsContext, uint)"/>
 		/// </summary>
-		[Test, ExpectedException(typeof(ArgumentException))]
+		[Test]
 		public void CreateCtxArray_Exception3()
 		{
-			using (ArrayBufferObjectBase arrayBuffer = CreateInstance()) {
-				arrayBuffer.Create(_Context, 0);
-			}
+			Assert.Throws<ArgumentException>(() => CreateInstance().Create(_Context, 0));
 		}
 
 		#endregion

--- a/OpenGL.Hal.Test/OpenGL.Hal.Test.csproj
+++ b/OpenGL.Hal.Test/OpenGL.Hal.Test.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenGL.Hal.Test</RootNamespace>
     <AssemblyName>OpenGL.Hal.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -63,11 +63,11 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="NSubstitute, Version=1.9.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca">
-      <HintPath>..\packages\NSubstitute.1.9.2.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="NSubstitute">
+      <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -139,7 +139,8 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(SolutionDir)Libs\ANGLE" "$(TargetDir)ANGLE\" /E /H /C /R /Q /Y &gt; NUL</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' != 'Unix' ">xcopy "$(SolutionDir)Libs\ANGLE" "$(TargetDir)ANGLE\" /E /H /C /R /Q /Y &gt; NUL</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">cp -r "$(SolutionDir)/Libs/ANGLE" "$(TargetDir)/ANGLE/"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/OpenGL.Hal.Test/packages.config
+++ b/OpenGL.Hal.Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NSubstitute" version="1.9.2.0" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
+  <package id="NUnit" version="3.2.0" targetFramework="net45" />
 </packages>

--- a/OpenGL.Hal/Scene/Terrain.cs
+++ b/OpenGL.Hal/Scene/Terrain.cs
@@ -187,7 +187,7 @@ namespace OpenGL.Scene
 			/// <summary>
 			/// Area of the dataset.
 			/// </summary>
-			public GeoTreeArea Area { get { return (new GeoTreeArea(Position, Size));  } }
+			public GeoTreeArea Area { get { return (new GeoTreeArea(Position, Size)); } }
 
 			/// <summary>
 			/// Position of the center of the dataset, in degrees using geodedic coordinates.
@@ -261,11 +261,13 @@ namespace OpenGL.Scene
 					throw new ArgumentNullException("dataset");
 
 				// Block size
-				using (Band datasetBand = dataset.GetRasterBand(1)) {
+				using (Band datasetBand = dataset.GetRasterBand(1))
+				{
 					datasetBand.GetBlockSize(out _BlockSize.x, out _BlockSize.y);
 
 					// Do not expose "rows": find a suitable block size
-					if (_BlockSize.x == 1 || _BlockSize.y == 1) {
+					if (_BlockSize.x == 1 || _BlockSize.y == 1)
+					{
 						const int DefaultBlockSize = 2048;
 
 						int blockSize = Math.Min(DefaultBlockSize, GraphicsContext.CurrentCaps.Limits.MaxTexture2DSize);
@@ -278,8 +280,10 @@ namespace OpenGL.Scene
 				}
 
 				// Cache blocks definitions
-				for (int x = 0; x < dataset.RasterXSize; x += _BlockSize.x) {
-					for (int y = 0; y < dataset.RasterYSize; y += _BlockSize.y) {
+				for (int x = 0; x < dataset.RasterXSize; x += _BlockSize.x)
+				{
+					for (int y = 0; y < dataset.RasterYSize; y += _BlockSize.y)
+					{
 						int wBlock = _BlockSize.x, hBlock = _BlockSize.y;
 
 						if (x + wBlock > dataset.RasterXSize)
@@ -374,14 +378,18 @@ namespace OpenGL.Scene
 
 			string[] datasetFiles = Directory.GetFiles(databaseRootPath, "*.*", SearchOption.AllDirectories);
 
-			foreach (string datasetPath in datasetFiles) {
-				try {
-					using (Dataset dataset = Gdal.OpenShared(datasetPath, Access.GA_ReadOnly)) {
+			foreach (string datasetPath in datasetFiles)
+			{
+				try
+				{
+					using (Dataset dataset = Gdal.OpenShared(datasetPath, Access.GA_ReadOnly))
+					{
 						GeoElevationTerrainDataset geoElevationTerrainDataset;
 
 						// Determine terrain dataset information and collect it
-						switch (dataset.GetDriver().ShortName) {
-							// Elevation datasets
+						switch (dataset.GetDriver().ShortName)
+						{
+						// Elevation datasets
 							case "EHdr":        // USGS DEM
 								if (datasetPath.ToLowerInvariant().EndsWith(".dem") == false)
 									continue;
@@ -398,7 +406,9 @@ namespace OpenGL.Scene
 
 						
 					}
-				} catch (Exception exception) {
+				}
+				catch (Exception exception)
+				{
 
 				}
 			}
@@ -447,8 +457,8 @@ namespace OpenGL.Scene
 			/// <exception cref="ArgumentNullException">
 			/// Exception thrown if <paramref name="datasetPath"/> or <paramref name="dataset"/> are null.
 			/// </exception>
-			public GeoElevationTerrainDataset(string datasetPath, Dataset dataset) :
-				base(datasetPath, dataset)
+			public GeoElevationTerrainDataset(string datasetPath, Dataset dataset)
+				: base(datasetPath, dataset)
 			{
 				
 			}

--- a/OpenGL.Net.Test/OpenGL.Net.Test.csproj
+++ b/OpenGL.Net.Test/OpenGL.Net.Test.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenGL.Test</RootNamespace>
     <AssemblyName>OpenGL.Net.Test</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -59,8 +59,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -94,9 +94,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -109,4 +106,7 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/OpenGL.Net.Test/packages.config
+++ b/OpenGL.Net.Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net20" />
+  <package id="NUnit" version="3.2.0" targetFramework="net45" />
 </packages>

--- a/OpenGL.Net/OpenGL.Net.csproj
+++ b/OpenGL.Net/OpenGL.Net.csproj
@@ -13,7 +13,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/Samples/HelloWorld/HelloWorld.csproj
+++ b/Samples/HelloWorld/HelloWorld.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HelloWorld</RootNamespace>
     <AssemblyName>HelloWorld</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
@@ -62,7 +62,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
@@ -130,7 +129,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(SolutionDir)Libs\ANGLE" "$(TargetDir)ANGLE\" /E /H /C /R /Q /Y &gt; NUL
+    <PostBuildEvent Condition=" '$(OS)' != 'Unix' ">xcopy "$(SolutionDir)Libs\ANGLE" "$(TargetDir)ANGLE\" /E /H /C /R /Q /Y &gt; NUL
 IF $(ConfigurationName) == "x64" (
   copy "$(SolutionDir)Libs\gdal-x64\*.dll" "$(TargetDir)"
   copy "$(SolutionDir)Libs\gdal-csharp\*.dll" "$(TargetDir)"
@@ -140,6 +139,7 @@ IF $(ConfigurationName) == "x64" (
 )
 
 rem copy "$(SolutionDir)\OpenGL.Hal.Plugins\OpenGL.Hal.LibTiff\$(ConfigurationName)\$(PlatformName)\*.dll" "$(TargetDir)" &gt; NUL</PostBuildEvent>
+	<PostBuildEvent Condition=" '$(OS)' == 'Unix' ">bash "$(SolutionDir)Scripts/postbuild.sh" "$(SolutionDir)" "$(TargetDir)" "$(ConfigurationName)"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Samples/HelloWorld/Program.cs
+++ b/Samples/HelloWorld/Program.cs
@@ -43,7 +43,7 @@ namespace HelloNewton
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
 
-			OpenGL.Scene.Terrain.Query(@"D:\__dds.cr.usgs.gov\srtm\version2_1\SRTM30\w180s10");
+			//OpenGL.Scene.Terrain.Query(@"D:\__dds.cr.usgs.gov\srtm\version2_1\SRTM30\w180s10");
 
 			// Check requirements
 			StringBuilder missingReq = new StringBuilder();
@@ -55,7 +55,8 @@ namespace HelloNewton
 			if (!GraphicsContext.CurrentCaps.GlExtensions.InstancedArrays)
 				missingReq.Append("- GL_ARB_instanced_arrays or OpenGL 3.2\n");
 
-			if (missingReq.Length > 0) {
+			if (missingReq.Length > 0)
+			{
 				MessageBox.Show(
 					String.Format("Unable to run sample. The following required extensions are not implemented:\n {0}", missingReq.ToString()),
 					"Error...", MessageBoxButtons.OK, MessageBoxIcon.Error

--- a/Scripts/postbuild.sh
+++ b/Scripts/postbuild.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+cp -r "$1/Libs/ANGLE" "$2/ANGLE/"
+
+if [ "$3" == "x64" ]; then 
+	cp "$1""Libs/gdal-x64/"*.dll "$2"
+	cp "$1""Libs/gdal-csharp/"*.dll "$2"
+else
+	cp "$1""Libs/gdal-x86/"*.dll "$2"
+	cp "$1""Libs/gdal-csharp/"*.dll "$2"
+fi


### PR DESCRIPTION
I've implemented a small number of fixes for the projects and tests which allows everything to build out of the box on Linux.

Full list of changes:
* Implemented OS sensitivity for postbuild events
* Added bash postbuild for Linux
* Updated NUnit to version 3
* Replaced deprecated ExpectedException test with Assert.Throws<T> in OpenGL.Hal.Tests
* Dropped required NET runtime to 4.5.0

Unfortunately, samples still will not run due to a TypeInitializationException. I suspect that there's a DLLConfig missing somewhere that prevents mono from communicating with the native OpenGL library. If nothing else, this is a start in the right direction for us Linuxers :)

EDIT: Here's the exception. Looks like it's not finding libGL properly.
https://gist.github.com/Nihlus/3b3977da6c47c89d20c139b9efa002fc