### PR TITLE
Tolerate extensions appearing twice in extension list

### DIFF
--- a/OpenGL.Net/KhronosApi.cs
+++ b/OpenGL.Net/KhronosApi.cs
@@ -596,7 +596,8 @@ namespace OpenGL
 				// Cache extension names in registry
 				_ExtensionsRegistry.Clear();
 				foreach (string extension in extensions)
-					_ExtensionsRegistry.Add(extension, true);
+					if (!_ExtensionsRegistry.ContainsKey(extension))
+						_ExtensionsRegistry.Add(extension, true);
 
 				// Set all extension fields
 				Type thisType = GetType();


### PR DESCRIPTION
If an extension name appears twice in the extension list then the context always fails to create.

How do you get an extension appearing twice in the extension list? I found it would happen when running through apitrace (https://github.com/apitrace/apitrace). APITrace wants your application to take advantage of debug extensions (like GL_ARB_debug_output) so it _unconditionally_ injects a bunch of extensions to the extension string. 

However, if your OpenGL implementation already advertised any of those extensions, that extension will now be in the list twice.