### PR TITLE
Fix copyright in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,24 @@
+ OpenGL.Net
+ Copyright (C) 2009-2016 Luca Piccioni
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, version 2.1 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+========================================================================
                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 2.1, February 1999
 
- Copyright (C) 2009-2016 Luca Piccioni
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
- The copyright you replaced was in regards to the LGPL, not your project. The license is copyrighted by FSF.
- Added copyright info on top, per example provided for GPL (https://www.gnu.org/licenses/gpl-howto.en.html)

Also consider adding the text of the original GPL, because LGPL acts as an extension and not a standalone license.
Source: https://www.gnu.org/licenses/gpl-howto.html (ctrl+f 'You should also include')