### PR TITLE
Allow DSA "Get" commands to have out params

### DIFF
--- a/BindingsGen/GLSpecs/CommandFlags.xml
+++ b/BindingsGen/GLSpecs/CommandFlags.xml
@@ -167,7 +167,7 @@
 
 	<!-- GL - Out Parameter -->
 
-	<command name="^glGet(Query(Object)?|Shader|Program|VertexAttrib|TexLevelParameter|ProgramInterface|TextureLevelParameter)u?i(64)?v(EXT)?$">
+	<command name="^glGet(Query(Object)?|Shader|Program|VertexAttrib|TexLevelParameter|ProgramInterface|TextureLevelParameter|TextureParameter(I)?)u?i(64)?v(EXT)?$">
 		<!-- Generate "out" overloads -->
 		<flags>OutParam</flags>
 	</command>

--- a/BindingsGen/GLSpecs/CommandFlags.xml
+++ b/BindingsGen/GLSpecs/CommandFlags.xml
@@ -167,7 +167,7 @@
 
 	<!-- GL - Out Parameter -->
 
-	<command name="^glGet(Query(Object)?|Shader|Program|VertexAttrib|TexLevelParameter|ProgramInterface)u?i(64)?v$">
+	<command name="^glGet(Query(Object)?|Shader|Program|VertexAttrib|TexLevelParameter|ProgramInterface|TextureLevelParameter)u?i(64)?v(EXT)?$">
 		<!-- Generate "out" overloads -->
 		<flags>OutParam</flags>
 	</command>


### PR DESCRIPTION
This PR intends to allow DSA commands such as glGetTextureLevelParameterEXT to have `out` parameters as well. There may be other such commands, but I am not sure yet.