### PR TITLE
New Sample: Windowless render start

### DIFF
--- a/OpenGL.Net.CoreUI/OpenGL.Net.CoreUI_net35.csproj
+++ b/OpenGL.Net.CoreUI/OpenGL.Net.CoreUI_net35.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>OpenGL.Net.CoreUI</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <BaseIntermediateOutputPath>obj\net35</BaseIntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OpenGL.Net.CoreUI/OpenGL.Net.CoreUI_net461.csproj
+++ b/OpenGL.Net.CoreUI/OpenGL.Net.CoreUI_net461.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <BaseIntermediateOutputPath>obj\net461</BaseIntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OpenGL.Net.Test/BenchmarkPInvoke.cs
+++ b/OpenGL.Net.Test/BenchmarkPInvoke.cs
@@ -84,11 +84,11 @@ namespace OpenGL.Test
 		///   pointing to the GL 1.4 implementation on Windows.
 		/// </remarks>
 		[SuppressUnmanagedCodeSecurity()]
-		[DllImport("opengl32.dll", EntryPoint = "glFlush", ExactSpelling = true)]
+		[DllImport("opengl32", EntryPoint = "glFlush", ExactSpelling = true)]
 		private extern static void glFlush();
 
 		[SuppressUnmanagedCodeSecurity()]
-		[DllImport("opengl32.dll", EntryPoint = "glEnable", ExactSpelling = true)]
+		[DllImport("opengl32", EntryPoint = "glEnable", ExactSpelling = true)]
 		internal extern static void glEnable(Int32 cap);
 
 		#endregion

--- a/OpenGL.Net/Egl.cs
+++ b/OpenGL.Net/Egl.cs
@@ -255,7 +255,7 @@ namespace OpenGL
 		/// <summary>
 		/// Default import library.
 		/// </summary>
-		internal const string Library = "libEGL.dll";
+		internal const string Library = "libEGL";
 
 		#endregion
 

--- a/OpenGL.Net/Gl.cs
+++ b/OpenGL.Net/Gl.cs
@@ -469,17 +469,17 @@ namespace OpenGL
 		/// <summary>
 		/// Default import library.
 		/// </summary>
-		internal const string Library = "opengl32.dll";
+		internal const string Library = "opengl32";
 
 		/// <summary>
 		/// Default import library.
 		/// </summary>
-		internal const string LibraryEs = "libGLESv1_CM.dll";
+		internal const string LibraryEs = "libGLESv1_CM";
 
 		/// <summary>
 		/// Default import library.
 		/// </summary>
-		internal const string LibraryEs2 = "libGLESv2.dll";
+		internal const string LibraryEs2 = "libGLESv2";
 
 		#endregion
 

--- a/OpenGL.Net/Glu.cs
+++ b/OpenGL.Net/Glu.cs
@@ -76,7 +76,7 @@ namespace OpenGL
 		/// <summary>
 		/// Default import library.
 		/// </summary>
-		internal const string Library = "Glu32.dll";
+		internal const string Library = "Glu32";
 
 		#endregion
 

--- a/OpenGL.Net/OpenGL.Net_net35.csproj
+++ b/OpenGL.Net/OpenGL.Net_net35.csproj
@@ -29,7 +29,6 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <ReleaseVersion>0.2.3</ReleaseVersion>
     <TargetFrameworkProfile />
     <BaseIntermediateOutputPath>obj\net35</BaseIntermediateOutputPath>
   </PropertyGroup>

--- a/OpenGL.Net/OpenGL.Net_net461.csproj
+++ b/OpenGL.Net/OpenGL.Net_net461.csproj
@@ -29,7 +29,6 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <ReleaseVersion>0.2.3</ReleaseVersion>
     <TargetFrameworkProfile />
     <BaseIntermediateOutputPath>obj\net461</BaseIntermediateOutputPath>
   </PropertyGroup>

--- a/OpenGL.Net/Wgl.cs
+++ b/OpenGL.Net/Wgl.cs
@@ -84,7 +84,7 @@ namespace OpenGL
 		/// <summary>
 		/// Default import library.
 		/// </summary>
-		private const string Library = "opengl32.dll";
+		private const string Library = "opengl32";
 
 		#endregion
 

--- a/OpenGL.Net_Mono.sln
+++ b/OpenGL.Net_Mono.sln
@@ -99,6 +99,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenGL.Net.CoreUI_net461", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloTriangle.CoreUI", "Samples\HelloTriangle.CoreUI\HelloTriangle.CoreUI.csproj", "{4981E3E9-2B94-4C3C-8A1D-8A5DEE831DAA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowlessTriangle", "Samples\WindowlessTriangle\WindowlessTriangle.csproj", "{8E0611A8-556A-4364-977E-4CD5767E1E62}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -291,6 +293,14 @@ Global
 		{4981E3E9-2B94-4C3C-8A1D-8A5DEE831DAA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4981E3E9-2B94-4C3C-8A1D-8A5DEE831DAA}.Release|x86.ActiveCfg = Release|Any CPU
 		{4981E3E9-2B94-4C3C-8A1D-8A5DEE831DAA}.Release|x86.Build.0 = Release|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Debug|x86.Build.0 = Debug|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Release|x86.ActiveCfg = Release|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -318,5 +328,6 @@ Global
 		{574716B9-F7D9-44C7-8E65-E5827EA031D0} = {81BBBDCD-40F4-43F2-BAA6-AE8280C19105}
 		{8BA9350B-43FB-4DD7-8F53-90F508795AE8} = {81BBBDCD-40F4-43F2-BAA6-AE8280C19105}
 		{4981E3E9-2B94-4C3C-8A1D-8A5DEE831DAA} = {C45EA757-D80F-48B1-B42F-5755F6F9897B}
+		{8E0611A8-556A-4364-977E-4CD5767E1E62} = {C45EA757-D80F-48B1-B42F-5755F6F9897B}
 	EndGlobalSection
 EndGlobal

--- a/OpenGL.Net_VC14.sln
+++ b/OpenGL.Net_VC14.sln
@@ -4,9 +4,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenGL.Net_net35", "OpenGL.Net\OpenGL.Net_net35.csproj", "{ABB8DFA8-473A-4FC1-85C0-E21680772A58}"
-	ProjectSection(ProjectDependencies) = postProject
-		{6CE61C1E-E93A-404A-89B7-1E8EA3BAF663} = {6CE61C1E-E93A-404A-89B7-1E8EA3BAF663}
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenGL.Net.Test_net35", "OpenGL.Net.Test\OpenGL.Net.Test_net35.csproj", "{861A0458-2848-4585-B844-8945E4B61B5C}"
 EndProject
@@ -73,9 +70,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OffscreenTriangle", "Samples\OffscreenTriangle\OffscreenTriangle.csproj", "{849A96E5-53A3-4D6C-AACA-7567F1A4AB46}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenGL.Net_net461", "OpenGL.Net\OpenGL.Net_net461.csproj", "{9E3018F3-770E-4CFD-87D0-BAEE66E9FE8F}"
-	ProjectSection(ProjectDependencies) = postProject
-		{6CE61C1E-E93A-404A-89B7-1E8EA3BAF663} = {6CE61C1E-E93A-404A-89B7-1E8EA3BAF663}
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenGL.Net.Test_net461", "OpenGL.Net.Test\OpenGL.Net.Test_net461.csproj", "{2C30C91A-47DB-4D35-8FA1-4BCE4DC4C1FE}"
 EndProject
@@ -128,6 +122,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloObjects_monodroid", "Samples\HelloObjects\HelloObjects_monodroid.csproj", "{0E0C62CB-3C9D-4632-B4C5-4B9DA8A7B7CC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenGL.Net.Objects.Test_net461", "OpenGL.Net.Objects.Test\OpenGL.Net.Objects.Test_net461.csproj", "{F53609AC-A012-4067-B122-7436832021BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowlessTriangle", "Samples\WindowlessTriangle\WindowlessTriangle.csproj", "{8E0611A8-556A-4364-977E-4CD5767E1E62}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -415,6 +411,14 @@ Global
 		{F53609AC-A012-4067-B122-7436832021BB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F53609AC-A012-4067-B122-7436832021BB}.Release|x86.ActiveCfg = Release|Any CPU
 		{F53609AC-A012-4067-B122-7436832021BB}.Release|x86.Build.0 = Release|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Debug|x86.Build.0 = Debug|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Release|x86.ActiveCfg = Release|Any CPU
+		{8E0611A8-556A-4364-977E-4CD5767E1E62}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -450,5 +454,6 @@ Global
 		{9C7DE463-47E4-49E3-9ECC-E892B48851D2} = {0250BB1C-FF02-4600-9E80-E7EF067C51B6}
 		{0E0C62CB-3C9D-4632-B4C5-4B9DA8A7B7CC} = {C45EA757-D80F-48B1-B42F-5755F6F9897B}
 		{F53609AC-A012-4067-B122-7436832021BB} = {0250BB1C-FF02-4600-9E80-E7EF067C51B6}
+		{8E0611A8-556A-4364-977E-4CD5767E1E62} = {C45EA757-D80F-48B1-B42F-5755F6F9897B}
 	EndGlobalSection
 EndGlobal

--- a/Samples/WindowlessTriangle/Program.cs
+++ b/Samples/WindowlessTriangle/Program.cs
@@ -1,17 +1,28 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
-
+using System.Linq;
+using System.Text;
 using OpenGL;
+
+// Dependency under Linux, specifically Ubuntu 16.04: sudo apt install libgles2-mesa-dev
 
 namespace WindowlessTriangle
 {
 	class Program
 	{
-		public static void Main(string[] args)
+		/// <summary>
+		/// The main entry point for the application.
+		/// </summary>
+		static void Main()
 		{
 			string envDebug = Environment.GetEnvironmentVariable("DEBUG");
-			if (envDebug == "GL")
+			if (envDebug == "GL"
+			    #if DEBUG
+			    || true
+			    #endif
+			)
 			{
 				KhronosApi.Log += delegate (object sender, KhronosLogEventArgs e)
 				{
@@ -20,7 +31,236 @@ namespace WindowlessTriangle
 				KhronosApi.LogEnabled = true;
 			}
 
+			try
+			{
+				Egl.IsRequired = Egl.IsAvailable;
 
+				// Render
+				using (var nativeBuffer = DeviceContext.CreatePBuffer(new DevicePixelFormat(24), 800, 600))
+				using (var deviceContext = DeviceContext.Create(nativeBuffer))
+				using (var bitmap = new Bitmap(800, 600, System.Drawing.Imaging.PixelFormat.Format32bppArgb))
+				{
+					Render(deviceContext, bitmap);
+					bitmap.Save("Result.png");
+				}
+			}
+			catch (Exception exception)
+			{
+				Console.WriteLine($"Unexpected exception: {exception}");
+			}
 		}
+
+		private static void Render(DeviceContext deviceContext, Bitmap result)
+		{
+			if (deviceContext == null)
+			{
+				throw new ArgumentNullException(nameof(deviceContext));
+			}
+			if (result == null)
+			{
+				throw new ArgumentNullException(nameof(result));
+			}
+
+			var glContext = IntPtr.Zero;
+			uint framebuffer = 0;
+			uint renderbuffer = 0;
+			uint shaderProgram = 0;
+
+			try
+			{
+				// Create context and make current on this thread
+				if ((glContext = deviceContext.CreateContext(IntPtr.Zero)) == IntPtr.Zero)
+				{
+					throw new Exception("GL Context creation failed");
+				}
+
+				deviceContext.MakeCurrent(glContext);
+
+				// Load shaders;
+				var shaderVars = new ShaderVariables();
+				shaderProgram = LoadShaders(_vertexShader, _fragmentShader, shaderVars);
+
+				// Create framebuffer resources
+				framebuffer = Gl.GenFramebuffer();
+				Gl.BindFramebuffer(FramebufferTarget.Framebuffer, framebuffer);
+
+				renderbuffer = Gl.GenRenderbuffer();
+				Gl.BindRenderbuffer(RenderbufferTarget.Renderbuffer, renderbuffer);
+				Gl.RenderbufferStorage(RenderbufferTarget.Renderbuffer, InternalFormat.Rgba8, result.Width, result.Height);
+				Gl.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, RenderbufferTarget.Renderbuffer, renderbuffer);
+
+				var status = Gl.CheckFramebufferStatus(FramebufferTarget.Framebuffer);
+				if (status != FramebufferStatus.FramebufferComplete)
+				{
+					Console.WriteLine($"!!!!!! Framebuffer not complete: {status}");
+				}
+
+				// Render onto bitmap
+				DrawObjects(result.Width, result.Height, shaderProgram, shaderVars);
+
+				var bitmapData = result.LockBits(new Rectangle(0, 0, result.Width, result.Height), ImageLockMode.WriteOnly, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+				try
+				{
+					Gl.ReadPixels(0, 0, result.Width, result.Height, OpenGL.PixelFormat.Rgba, PixelType.UnsignedByte, bitmapData.Scan0);
+				}
+				finally
+				{
+					result.UnlockBits(bitmapData);
+				}
+			}
+			finally
+			{
+				if (shaderProgram != 0)
+					Gl.DeleteProgram(shaderProgram);
+
+				Gl.BindRenderbuffer(RenderbufferTarget.Renderbuffer, 0);
+				if (renderbuffer != 0)
+					Gl.DeleteRenderbuffers(renderbuffer);
+
+				Gl.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+				if (framebuffer != 0)
+					Gl.DeleteFramebuffers(framebuffer);
+
+				if (glContext != IntPtr.Zero)
+					deviceContext.DeleteContext(glContext);
+			}
+		}
+
+		private static void DrawObjects(int w, int h, uint shaderProgram, ShaderVariables shaderVars)
+		{
+			var projectionMatrix = new OrthoProjectionMatrix(0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f);
+
+			Gl.Viewport(0, 0, w, h);
+
+			Gl.ClearColor(0.0f, 0.0f, 0.0f, 0.0f); // BGRA because of messed up mismatch between OpenGL and C#: the former is RGBA, the latter is ARGB, and it's really easy to royally confused.
+			Gl.ClearDepth(0);
+			Gl.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+
+			Gl.UseProgram(shaderProgram);
+
+			using (var arrayPosition = new MemoryLock(_arrayPosition))
+			using (var arrayColor = new MemoryLock(_arrayColor))
+			{
+				Gl.VertexAttribPointer(shaderVars.Attributes["aPosition"], 3, VertexAttribType.Float, false, 0, arrayPosition.Address);
+				Gl.EnableVertexAttribArray(shaderVars.Attributes["aPosition"]);
+
+				Gl.VertexAttribPointer(shaderVars.Attributes["aColor"], 4, VertexAttribType.Float, false, 0, arrayColor.Address);
+				Gl.EnableVertexAttribArray(shaderVars.Attributes["aColor"]);
+
+				Gl.UniformMatrix4(shaderVars.Uniforms["uMVP"], 1, false, projectionMatrix.ToArray());
+
+				Gl.DrawArrays(PrimitiveType.Triangles, 0, 3);
+			}
+		}
+
+		private static uint LoadShaders(string vertexShaderSource, string fragmentShaderSource, ShaderVariables shaderVars)
+		{
+			var infolog = new StringBuilder(1024);
+			int infologLength;
+			int compiled;
+
+			// Vertex shader
+			var vertexShader = Gl.CreateShader(ShaderType.VertexShader);
+			var shaderLines = vertexShaderSource.Split('\n').Select(line => line.TrimEnd() + "\n").ToArray();
+			Gl.ShaderSource(vertexShader, shaderLines);
+			Gl.CompileShader(vertexShader);
+			Gl.GetShader(vertexShader, ShaderParameterName.CompileStatus, out compiled);
+			if (compiled == Gl.FALSE)
+			{
+				Gl.GetShaderInfoLog(vertexShader, 1024, out infologLength, infolog);
+			}
+
+			// Fragment shader
+			var fragmentShader = Gl.CreateShader(ShaderType.FragmentShader);
+			Gl.ShaderSource(fragmentShader, fragmentShaderSource.Split('\n').Select(line => line.TrimEnd() + "\n").ToArray());
+			Gl.CompileShader(fragmentShader);
+			Gl.GetShader(fragmentShader, ShaderParameterName.CompileStatus, out compiled);
+			if (compiled == Gl.FALSE)
+			{
+				Gl.GetShaderInfoLog(fragmentShader, 1024, out infologLength, infolog);
+			}
+
+			// Program
+			var program = Gl.CreateProgram();
+			Gl.AttachShader(program, vertexShader);
+			Gl.AttachShader(program, fragmentShader);
+			Gl.LinkProgram(program);
+
+			int linked;
+			Gl.GetProgram(program, Gl.LINK_STATUS, out linked);
+			if (linked == Gl.FALSE)
+			{
+				Gl.GetProgramInfoLog(program, 1024, out infologLength, infolog);
+			}
+
+			// Get and store the variable locations, could do with some error detection.
+			var uniformKeys = new List<string>(shaderVars.Uniforms.Keys);
+			foreach (var varName in uniformKeys)
+			{
+				shaderVars.Uniforms[varName] = Gl.GetUniformLocation(program, varName);
+			}
+
+			var attributeKeys = new List<string>(shaderVars.Attributes.Keys);
+			foreach (var varName in attributeKeys)
+			{
+				shaderVars.Attributes[varName] = (uint)Gl.GetAttribLocation(program, varName);
+			}
+
+			// Clean up
+			Gl.DetachShader(program, vertexShader);
+			Gl.DetachShader(program, fragmentShader);
+			Gl.DeleteShader(vertexShader);
+			Gl.DeleteShader(fragmentShader);
+
+			return program;
+		}
+
+		private class ShaderVariables
+		{
+			// Uniforms
+			public Dictionary<string, int> Uniforms = new Dictionary<string, int>()
+			{
+				["uMVP"] = 0,
+			};
+
+			// Attributes
+			public Dictionary<string, uint> Attributes = new Dictionary<string, uint>()
+			{
+				["aPosition"] = 0,
+				["aColor"] = 0,
+			};
+		}
+
+		private static string _vertexShader = @"
+uniform mat4 uMVP;
+attribute vec3 aPosition;
+attribute vec4 aColor;
+varying vec4 vColor;
+void main() {
+	gl_Position = uMVP * vec4(aPosition, 1.0);
+	vColor = aColor;
+}
+";
+
+		private static string _fragmentShader = @"
+precision mediump float;
+varying vec4 vColor;
+void main() {
+	gl_FragColor = vColor.bgra; /* Swizzle the color to match the Bitmap's color order*/
+}
+";
+
+		private static readonly float[] _arrayPosition = new float[] {
+			0.0f, 0.0f, 0.0f,
+			0.5f, 1.0f, 0.0f,
+			1.0f, 0.0f, 0.0f,
+		};
+
+		private static readonly float[] _arrayColor = new float[] {
+			1.0f, 0.0f, 0.0f, 1.0f,
+			0.0f, 1.0f, 0.0f, 1.0f,
+			0.0f, 0.0f, 1.0f, 1.0f,
+		};
+
 	}
 }

--- a/Samples/WindowlessTriangle/Program.cs
+++ b/Samples/WindowlessTriangle/Program.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+using OpenGL;
+
+namespace WindowlessTriangle
+{
+	class Program
+	{
+		public static void Main(string[] args)
+		{
+			string envDebug = Environment.GetEnvironmentVariable("DEBUG");
+			if (envDebug == "GL")
+			{
+				KhronosApi.Log += delegate (object sender, KhronosLogEventArgs e)
+				{
+					Console.WriteLine(e.ToString());
+				};
+				KhronosApi.LogEnabled = true;
+			}
+
+
+		}
+	}
+}

--- a/Samples/WindowlessTriangle/Properties/AssemblyInfo.cs
+++ b/Samples/WindowlessTriangle/Properties/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("WindowlessTriangle")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("Richard Curtice")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/Samples/WindowlessTriangle/WindowlessTriangle.csproj
+++ b/Samples/WindowlessTriangle/WindowlessTriangle.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8E0611A8-556A-4364-977E-4CD5767E1E62}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>WindowlessTriangle</RootNamespace>
+    <AssemblyName>WindowlessTriangle</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <LangVersion>6</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <LangVersion>6</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Drawing" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\OpenGL.Net\OpenGL.Net_net461.csproj">
+      <Project>{9E3018F3-770E-4CFD-87D0-BAEE66E9FE8F}</Project>
+      <Name>OpenGL.Net_net461</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
This adds a new sample that uses Egl to render a triangle without using any window.  This involved some semi-invasive changes to the GetProcAddress class to make the source choosable: X11 is NOT guaranteed to be installed and shouldn't be forced as a dependency when it's not needed.

However there are still some problems to work out:
1. Egl.cs need to NOT attempt to `GetProcAddressX11.GetLibraryHandle("libGLESv2.so", false);` under Linux.  To solve this I propose finding some way to identify the Raspberry PI as its own platform.  As it stands the new sample will crash because it tries to initialize the X11 interface and fails.  For testing I'm simply commenting out that line for now.
2. When running without X11 I still am getting crashes.  I'm in the process of hunting that down, seems to be that eglInitialize is returning false for some reason. https://devblogs.nvidia.com/parallelforall/egl-eye-opengl-visualization-without-x-server/ indicates that it should be OK with this...