### PR TITLE
Fix .NET standard 2.0 build

### DIFF
--- a/OpenGL.Net/OpenGL.Net_netstd2.0.csproj
+++ b/OpenGL.Net/OpenGL.Net_netstd2.0.csproj
@@ -1,4 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
+
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>obj\netstd2.0</BaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -14,12 +20,10 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <BaseIntermediateOutputPath>obj\netstd2.0</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <BaseIntermediateOutputPath>obj\netstd2.0</BaseIntermediateOutputPath>
   </PropertyGroup>
   
   <ItemGroup>
@@ -47,5 +51,7 @@
   </ItemGroup>
 
   <Import Project="..\Khronos.Net\Khronos.Net.projitems" Label="Shared" />
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>


### PR DESCRIPTION
The .NET standard 2.0 build was failing since BaseIntermediateOutputPath should not be set from the "main body" of the project file.

I've fixed this by moving it to the the top of the project file and explicitly importing the Sdk props and targets after it.