### PR TITLE
Fix netcoreapp projects for Linux

### DIFF
--- a/Khronos.Net/GetProcAddressOS.cs
+++ b/Khronos.Net/GetProcAddressOS.cs
@@ -306,12 +306,19 @@ namespace Khronos
 
 			public const int RTLD_NOW = 2;
 
+#if NETCORE
+			[DllImport("dl")]
+			public static extern IntPtr dlopen(string filename, int flags);
+
+			[DllImport("dl")]
+			public static extern IntPtr dlsym(IntPtr handle, string symbol);
+#else
 			[DllImport("dl")]
 			public static extern IntPtr dlopen([MarshalAs(UnmanagedType.LPTStr)] string filename, int flags);
 
 			[DllImport("dl")]
 			public static extern IntPtr dlsym(IntPtr handle, [MarshalAs(UnmanagedType.LPTStr)] string symbol);
-
+#endif
 			[DllImport("dl")]
 			public static extern string dlerror();
 		}

--- a/OpenGL.Net.CoreUI/OpenGL.Net.CoreUI_netcore2.0.csproj
+++ b/OpenGL.Net.CoreUI/OpenGL.Net.CoreUI_netcore2.0.csproj
@@ -1,4 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
+
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -16,7 +22,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\Release\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;RELEASE;NETCOREAPP2_0</DefineConstants>
     <DocumentationFile>bin\netcore\Release\netcoreapp2.0\OpenGL.Net.CoreUI.xml</DocumentationFile>
   </PropertyGroup>
@@ -24,35 +29,30 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\Release\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;RELEASE;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\Release\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;RELEASE;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\Debug\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\Debug\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\Debug\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
@@ -65,5 +65,7 @@
   <ItemGroup>
     <ProjectReference Include="..\OpenGL.Net\OpenGL.Net_netcore1.1.csproj" />
   </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/OpenGL.Net.Test/OpenGL.Net.Test_netcore2.0.csproj
+++ b/OpenGL.Net.Test/OpenGL.Net.Test_netcore2.0.csproj
@@ -1,4 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
+
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>obj\netcore2.0</BaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -10,14 +16,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>bin\netcore\Release</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <BaseIntermediateOutputPath>obj\netcore2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;RELEASE;NETCORE;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\Debug</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcore2.0</BaseIntermediateOutputPath>
     <DefineConstants>NETCORE;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
@@ -137,5 +141,7 @@
       <DependentUpon>Vertex4.tt</DependentUpon>
     </Compile>
   </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/OpenGL.Net/OpenGL.Net.Math_netcore2.0.csproj
+++ b/OpenGL.Net/OpenGL.Net.Math_netcore2.0.csproj
@@ -1,4 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
+
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -16,7 +22,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\Release</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;RELEASE;NETCOREAPP2_0</DefineConstants>
     <DocumentationFile>bin\netcore\Release\netcoreapp2.0\OpenGL.Net.Math.xml</DocumentationFile>
     <NoWarn>1701;1702;1705;1734</NoWarn>
@@ -25,21 +30,18 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\x86\Release</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;RELEASE;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\Debug</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\x86\Debug</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
@@ -270,5 +272,6 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.3.0" />
   </ItemGroup>
 
-  
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
 </Project>

--- a/OpenGL.Net/OpenGL.Net_netcore2.0.csproj
+++ b/OpenGL.Net/OpenGL.Net_netcore2.0.csproj
@@ -1,4 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
+
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -16,7 +22,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\Release</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;HAVE_NUMERICS;RELEASE;NETCOREAPP2_0</DefineConstants>
     <DocumentationFile>bin\netcore\Release\netcoreapp2.0\OpenGL.Net.xml</DocumentationFile>
     <NoWarn>1701;1702;1705;1734</NoWarn>
@@ -25,21 +30,18 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\x86\Release</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;HAVE_NUMERICS;RELEASE;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\Debug</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;HAVE_NUMERICS;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <OutputPath>bin\netcore\x86\Debug</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
     <DefineConstants>TRACE;NETCORE;HAVE_NUMERICS;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
@@ -112,5 +114,7 @@
   </ItemGroup>
 
   <Import Project="..\Khronos.Net\Khronos.Net.projitems" Label="Shared" />
+  
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/OpenGL.Net/Properties/AssemblyInfo.cs
+++ b/OpenGL.Net/Properties/AssemblyInfo.cs
@@ -31,10 +31,8 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-#if !NETCORE
 [assembly: AssemblyVersion("0.4.0")]
 [assembly: AssemblyFileVersion("0.4.0")]
-#endif
 
 [assembly: InternalsVisibleTo("OpenGL.Net.VideoCore")]
 [assembly: InternalsVisibleTo("OpenWF.Net")]

--- a/Samples/HelloTriangle.NETCore/HelloTriangle.NETCore2.0.csproj
+++ b/Samples/HelloTriangle.NETCore/HelloTriangle.NETCore2.0.csproj
@@ -1,4 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
+
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,32 +15,26 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>bin\netcoreapp2.0\Release\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutputPath>bin\netcoreapp2.0\Release\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <OutputPath>bin\netcoreapp2.0\Release\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>bin\netcoreapp2.0\Debug\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutputPath>bin\netcoreapp2.0\Debug\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
     <OutputPath>bin\netcoreapp2.0\Debug\</OutputPath>
-    <BaseIntermediateOutputPath>obj\netcoreapp2.0</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -47,5 +47,7 @@
     <ProjectReference Include="..\..\OpenGL.Net.CoreUI\OpenGL.Net.CoreUI_netcore2.0.csproj" />
     <ProjectReference Include="..\..\OpenGL.Net\OpenGL.Net_netcore2.0.csproj" />
   </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>


### PR DESCRIPTION
This should get the netcoreapp2.0 projects building again, and running on Linux. I've only tested this building with Visual Studio 2017 and running on Windows 10 (WGL) & Ubuntu 18.04 (GLX). 

On Ubuntu, I had to create the symlink `/usr/lib/x86_64-linux-gnu/libX11.so -> /usr/lib/x86_64-linux-gnu/libX11.so.6` in addition to these changes. This isn't required under Mono because Mono supports [DLLMap](https://www.mono-project.com/docs/advanced/pinvoke/dllmap/). While .NET Core doesn't support DLLMap, Core 3.0 is adding [similar functionality](https://github.com/dotnet/samples/tree/master/core/extensions/DllMapDemo).


Project file changes were copied from pull request #101 to fix issues with the use of `BaseIntermediateOutputPath` in order to get the project files to load properly.

I added #defines around the `dlopen` DllImports to account for marshaling differences, as noted in issue #107.

Finally, I removed the #define around the version info in AssemblyInfo.cs. This was causing assembly load errors because the assembly had an incorrect version (0.0.0.0).