### PR TITLE
Update GetProcAddressOS.cs

### DIFF
--- a/Khronos.Net/GetProcAddressOS.cs
+++ b/Khronos.Net/GetProcAddressOS.cs
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// Macro utility for logging platform-relared function calls
+// Macro utility for logging platform-related function calls
 #undef PLATFORM_LOG_ENABLED
 
 using System;
@@ -307,19 +307,19 @@ namespace Khronos
 			public const int RTLD_NOW = 2;
 
 #if NETCORE
-			[DllImport("dl")]
+			[DllImport("libc")]
 			public static extern IntPtr dlopen(string filename, int flags);
 
-			[DllImport("dl")]
+			[DllImport("libc")]
 			public static extern IntPtr dlsym(IntPtr handle, string symbol);
 #else
-			[DllImport("dl")]
+			[DllImport("libc")]
 			public static extern IntPtr dlopen([MarshalAs(UnmanagedType.LPTStr)] string filename, int flags);
 
-			[DllImport("dl")]
+			[DllImport("libc")]
 			public static extern IntPtr dlsym(IntPtr handle, [MarshalAs(UnmanagedType.LPTStr)] string symbol);
 #endif
-			[DllImport("dl")]
+			[DllImport("libc")]
 			public static extern string dlerror();
 		}
 
@@ -328,10 +328,10 @@ namespace Khronos
 		#region IGetProcAdress Implementation
 
 		/// <summary>
-		/// Add a path of a directory as additional path for searching libraries.
+		/// Add a path of a directory as an additional path for searching libraries.
 		/// </summary>
 		/// <param name="libraryDirPath">
-		/// A <see cref="string"/> that specify the absolute path of the directory where the libraries are loaded using
+		/// A <see cref="string"/> that specifies the absolute path of the directory where the libraries are loaded using
 		/// <see cref="GetProcAddress(string, string)"/> method.
 		/// </param>
 		public void AddLibraryDirectory(string libraryDirPath)


### PR DESCRIPTION
glibc 2.34 removed the functionality of the dl library into libc.  
https://lists.gnu.org/archive/html/info-gnu/2021-08/msg00001.html

Since then, all Linux distributions (and I assume also macOS) can not load `dl` anymore. 

This fixes it.

And I also fixed a couple of typos on my way. 🙂 